### PR TITLE
Fixed array initialization issue in category helper. Fixes #9

### DIFF
--- a/core/news.php
+++ b/core/news.php
@@ -17,7 +17,7 @@ function cn_bb_decode($bb)
 
 function cn_helper_category($e)
 {
-    $nice = '';
+    $nice = array();
     $cat = cn_get_categories(TRUE);
 
     $sp = spsep($e['c']);


### PR DESCRIPTION
The array `$nice` in function `cn_helper_category($e)`was initialized with an empty string which caused an Error in PHP 7.1 and above. Changing this initialization to `$nice = array();` fixes this issue.