### PR TITLE
Harden security in dashboard.php

### DIFF
--- a/core/modules/dashboard.php
+++ b/core/modules/dashboard.php
@@ -552,16 +552,25 @@ function dashboard_personal()
             if ($uploads_dir) {
 
                 $imgsize = getimagesize($avatar_tmp);
-                if (!empty($imgsize[0]) && !empty($imgsize[1])) {
+                if ($imgsize !== FALSE) && (!empty($imgsize[0]) && !empty($imgsize[1])) {
 
-                    if (preg_match('/(jpg|jpeg|gif|png)/i', $imgsize['mime'])) {
+                    if ((imgsize[2] === IMAGETYPE_JPEG) || (imgsize[2] === IMAGETYPE_PNG) || (imgsize[2] === IMAGETYPE_GIF)) {
 
                         // remove old avatar
-                        $file_name = 'avatar_' . $member['name'] . '_' . $avatar_file['name'];
-                        if (isset($member['avatar']) && $member['avatar'] != $file_name) {
+						$permitted_chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+						$randompart =  substr(str_shuffle($permitted_chars), 0, 8);
+						if (imgsize[2] === IMAGETYPE_JPEG) {
+							$avatar_ext = '.jpg'
+						} else if (imgsize[2] === IMAGETYPE_PNG) {
+							$avatar_ext = '.png'
+						} else {
+							$avatar_ext = '.txt'
+						}
+                        $file_name = 'avatar_' . $member['name'] . '_' . $randompart . '_' . $avatar_ext;
+                        if (isset($member['avatar']) {
                             unlink($uploads_dir . $member['avatar']);
                         }
-
+						
                         if (move_uploaded_file($avatar_file['tmp_name'], $uploads_dir . $file_name)) {
 
                             $correct = true;


### PR DESCRIPTION
1. Switch from using pgrep to compare against getimagesize()['mime']
   to directly comparing IMAGETYPEs against getimagesize()[2].

2. Replace user-supplied filename with a random string, and supply
   an extension based on the image type provided by getimagesize().

WARNING:  THESE FIXES DO NOT FIX THE UNDERLYING PROBLEM.  THIS CAN
ONLY BE FIXED BY FORBIDDING SCRIPT EXECUTION IN THE UPLOADS DIRECTORY!!!!

Note:  Only the second fix is likely to improve security.  The first one should be a speed improvement (greps are relatively expensive).  I also added a missing check to make sure getimagesize() didn't return FALSE.

Again, this does NOT fully fix the issue, it only mitigates it.  A full fix is only possible (as far as I can tell) by either disabling user avatars or making sure no scripts can be run in the uploads folder.